### PR TITLE
Remove environment prefix setting from configuration initialization

### DIFF
--- a/cmd/report/root.go
+++ b/cmd/report/root.go
@@ -39,7 +39,6 @@ func init() {
 		log.WithField("error", err).Warnln("Failed to read configuration file")
 	}
 
-	viper.SetEnvPrefix("app")
 	viper.AutomaticEnv()
 
 	conf := config.GetConfig()


### PR DESCRIPTION
This pull request includes a small change to the `cmd/report/root.go` file. The change removes the `viper.SetEnvPrefix("app")` line from the `func init() {` function.

* [`cmd/report/root.go`](diffhunk://#diff-0c1bdbb0db853c85f985833ba3845ff403571d2758e578c4c490ff8cbd8026faL42): Removed the `viper.SetEnvPrefix("app")` line from the `func init() {` function.